### PR TITLE
Header / Storybook / DB cleanup

### DIFF
--- a/web/src/components/DisplayText/DisplayText.stories.tsx
+++ b/web/src/components/DisplayText/DisplayText.stories.tsx
@@ -1,15 +1,3 @@
-// Pass props to your component by passing an `args` object to your story
-//
-// ```tsx
-// export const Primary: Story = {
-//  args: {
-//    propName: propValue
-//  }
-// }
-// ```
-//
-// See https://storybook.js.org/docs/7/writing-stories/args
-
 import type { Meta, StoryObj } from '@storybook/react'
 
 import DisplayText from './DisplayText'
@@ -23,10 +11,34 @@ export default meta
 
 type Story = StoryObj<typeof DisplayText>
 
-export const Primary: Story = {
+export const BlackOutline: Story = {
   args: {
     solidText: 'submit',
     outlineText: 'a link',
+    solidTextColor: 'black',
+    outlineColor: 'black',
+  },
+  decorators: [
+    (Story) => (
+      <div className="bg-yellow  p-3">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export const BlueOutline: Story = {
+  args: {
+    solidText: 'forgot',
+    outlineText: 'password',
+    solidTextColor: 'white',
     outlineColor: 'blue',
   },
+  decorators: [
+    (Story) => (
+      <div className="bg-black p-3">
+        <Story />
+      </div>
+    ),
+  ],
 }

--- a/web/src/components/DisplayText/DisplayText.test.tsx
+++ b/web/src/components/DisplayText/DisplayText.test.tsx
@@ -2,15 +2,13 @@ import { render, screen } from '@redwoodjs/testing/web'
 
 import DisplayText from './DisplayText'
 
-//   Improve this test with help from the Redwood Testing Doc:
-//    https://redwoodjs.com/docs/testing#testing-components
-
 describe('DisplayText', () => {
   it('renders successfully', () => {
     expect(() => {
       render(
         <DisplayText
           solidText="submit"
+          solidTextColor="black"
           outlineText="a link"
           outlineColor="black"
         />
@@ -21,11 +19,13 @@ describe('DisplayText', () => {
   it('shows the correct outline color', () => {
     render(
       <DisplayText
-        solidText="submit"
-        outlineText="a link"
+        solidText="forgot"
+        solidTextColor="white"
+        outlineText="password"
         outlineColor="blue"
       />
     )
-    expect(screen.getByText('a link')).toHaveClass('text-stroke-color-blue')
+    expect(screen.getByText('password')).toHaveClass('text-stroke-color-blue')
+    expect(screen.getByText('forgot')).toHaveClass('text-white')
   })
 })

--- a/web/src/components/DisplayText/DisplayText.tsx
+++ b/web/src/components/DisplayText/DisplayText.tsx
@@ -1,21 +1,29 @@
 const DisplayText = ({
   solidText,
+  solidTextColor,
   outlineText,
   outlineColor,
 }: {
   solidText: string
+  solidTextColor: 'white' | 'black'
   outlineText: string
-  outlineColor: 'black' | 'blue' | 'yellow'
+  outlineColor: 'black' | 'blue'
 }) => {
+  const solidTextColorClasses = {
+    white: 'text-white',
+    black: 'text-black',
+  }
+
   const outlineColorClasses = {
     black: 'text-stroke-color-black',
     blue: 'text-stroke-color-blue',
-    yellow: 'text-stroke-color-yellow',
   }
 
   return (
     <div className="flex w-full flex-wrap gap-2 leading-none">
-      <p className="min-w-fit font-serif text-[min(20vw,14rem)] font-bold uppercase">
+      <p
+        className={`min-w-fit font-serif text-[min(20vw,14rem)] font-bold uppercase ${solidTextColorClasses[solidTextColor]}`}
+      >
         {solidText}
       </p>
       <p

--- a/web/src/components/Header/Header.stories.tsx
+++ b/web/src/components/Header/Header.stories.tsx
@@ -4,22 +4,28 @@ import { AuthProvider } from '../../auth'
 
 import Header from './Header'
 
+const meta: Meta<typeof Header> = {
+  component: Header,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="relative">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export default meta
+
 const LoggedInDecorator = (Story) => {
   mockCurrentUser({ id: 1 })
-
   return (
     <AuthProvider>
       <Story />
     </AuthProvider>
   )
 }
-
-const meta: Meta<typeof Header> = {
-  component: Header,
-  tags: ['autodocs'],
-}
-
-export default meta
 
 type Story = StoryObj<typeof Header>
 

--- a/web/src/components/Header/Header.tsx
+++ b/web/src/components/Header/Header.tsx
@@ -4,8 +4,8 @@ const Header = () => {
   return (
     <>
       <Navigation />
-      <div className="pointer-events-none relative bg-black">
-        <h1 className="text-nowrap pt-4 text-center font-serif text-[clamp(3.5rem,12vw,11rem)] font-bold leading-[0.875] tracking-wider text-yellow">
+      <div className="pointer-events-none relative w-full bg-black">
+        <h1 className="whitespace-nowrap pt-4 text-center font-serif text-[11vw] font-bold leading-[0.875] tracking-wider text-yellow md:text-[10vw]">
           Brazilian Nut{' '}
           <span className="text-stroke-width text-stroke-color-yellow text-transparent">
             News

--- a/web/src/components/Header/Header.tsx
+++ b/web/src/components/Header/Header.tsx
@@ -2,20 +2,20 @@ import Navigation from '../Navigation/Navigation'
 
 const Header = () => {
   return (
-    <div className="grid grid-cols-1 grid-rows-[0.75fr_1fr]">
+    <>
       <Navigation />
-      <div className="col-start-1 col-end-2 row-start-1 row-end-3 h-28 bg-black">
-        <h1 className="mx-auto text-nowrap text-center font-serif text-[clamp(4rem,8.5vw,9rem)] font-bold leading-[1.5] tracking-wider text-yellow">
+      <div className="pointer-events-none relative bg-black">
+        <h1 className="text-nowrap pt-4 text-center font-serif text-[clamp(3.5rem,12vw,11rem)] font-bold leading-[0.875] tracking-wider text-yellow">
           Brazilian Nut{' '}
           <span className="text-stroke-width text-stroke-color-yellow text-transparent">
             News
           </span>
         </h1>
-        <p className="absolute right-4 top-20 bg-black px-4 font-display uppercase text-yellow">
+        <p className="absolute bottom-9 right-0 bg-black px-4 font-display uppercase text-yellow">
           Where the best news rises to the top
         </p>
       </div>
-    </div>
+    </>
   )
 }
 

--- a/web/src/components/Navigation/Navigation.stories.tsx
+++ b/web/src/components/Navigation/Navigation.stories.tsx
@@ -4,22 +4,35 @@ import { AuthProvider } from '../../auth'
 
 import Navigation from './Navigation'
 
+const meta: Meta<typeof Navigation> = {
+  component: Navigation,
+  tags: ['autodocs'],
+  parameters: {
+    docs: {
+      story: {
+        height: '50px',
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="relative">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+export default meta
+
 const LoggedInDecorator = (Story) => {
   mockCurrentUser({ id: 1 })
-
   return (
     <AuthProvider>
       <Story />
     </AuthProvider>
   )
 }
-
-const meta: Meta<typeof Navigation> = {
-  component: Navigation,
-  tags: ['autodocs'],
-}
-
-export default meta
 
 type Story = StoryObj<typeof Navigation>
 

--- a/web/src/components/Navigation/Navigation.tsx
+++ b/web/src/components/Navigation/Navigation.tsx
@@ -6,7 +6,7 @@ const Navigation = () => {
   const { isAuthenticated, logOut } = useAuth()
 
   return (
-    <nav className="absolute top-0 z-10 flex h-11 w-full items-center justify-end gap-1 bg-black p-3 drop-shadow-md">
+    <nav className="absolute top-0 z-10 flex h-12 w-full items-center justify-end gap-1 bg-black p-3 drop-shadow-md">
       {isAuthenticated ? (
         <div className="grid w-full grid-flow-col grid-cols-6 items-center">
           <div className="col-span-4 flex">

--- a/web/src/components/Navigation/Navigation.tsx
+++ b/web/src/components/Navigation/Navigation.tsx
@@ -6,7 +6,7 @@ const Navigation = () => {
   const { isAuthenticated, logOut } = useAuth()
 
   return (
-    <nav className="z-1 col-start-1 col-end-2 row-start-1 row-end-2 flex h-11 items-center justify-end gap-1 bg-black p-3 drop-shadow-md">
+    <nav className="absolute top-0 z-10 flex h-11 w-full items-center justify-end gap-1 bg-black p-3 drop-shadow-md">
       {isAuthenticated ? (
         <div className="grid w-full grid-flow-col grid-cols-6 items-center">
           <div className="col-span-4 flex">

--- a/web/src/components/SharedLinksCell/SharedLinksCell.tsx
+++ b/web/src/components/SharedLinksCell/SharedLinksCell.tsx
@@ -53,7 +53,7 @@ export const Success = ({
           link.submittedBy.email.slice(0, link.submittedBy.email.indexOf('@'))
         return (
           <SharedLink
-            key={link.id}
+            key={link.title}
             title={link.title}
             link={link.url}
             username={userName}

--- a/web/src/components/SubmitLinkForm/SubmitLinkForm.stories.tsx
+++ b/web/src/components/SubmitLinkForm/SubmitLinkForm.stories.tsx
@@ -1,15 +1,3 @@
-// Pass props to your component by passing an `args` object to your story
-//
-// ```tsx
-// export const Primary: Story = {
-//  args: {
-//    propName: propValue
-//  }
-// }
-// ```
-//
-// See https://storybook.js.org/docs/7/writing-stories/args
-
 import type { Meta, StoryObj } from '@storybook/react'
 
 import SubmitLinkForm from './SubmitLinkForm'
@@ -17,15 +5,45 @@ import SubmitLinkForm from './SubmitLinkForm'
 const meta: Meta<typeof SubmitLinkForm> = {
   component: SubmitLinkForm,
   tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="bg-yellow px-7 py-5">
+        <Story />
+      </div>
+    ),
+  ],
 }
 
 export default meta
 
 type Story = StoryObj<typeof SubmitLinkForm>
 
-export const Primary: Story = {
+export const InitialState: Story = {
   args: {
     loading: false,
     error: null,
+  },
+}
+
+export const FormError: Story = {
+  args: {
+    loading: false,
+    error: {
+      message: 'Links should be valid urls, starting with https://',
+      graphQLErrors: [
+        {
+          message: 'Links should be valid urls, starting with https://',
+          extensions: {
+            code: 'BAD_USER_INPUT',
+            properties: {
+              messages: {
+                url: ['Links should be valid urls, starting with https://'],
+              },
+            },
+          },
+        },
+      ],
+      networkError: null,
+    },
   },
 }

--- a/web/src/layouts/MainLayout/MainLayout.stories.tsx
+++ b/web/src/layouts/MainLayout/MainLayout.stories.tsx
@@ -4,6 +4,13 @@ import MainLayout from './MainLayout'
 
 const meta: Meta<typeof MainLayout> = {
   component: MainLayout,
+  decorators: [
+    (Story) => (
+      <div className="relative">
+        <Story />
+      </div>
+    ),
+  ],
 }
 
 export default meta

--- a/web/src/pages/HomePage/HomePage.stories.tsx
+++ b/web/src/pages/HomePage/HomePage.stories.tsx
@@ -8,9 +8,11 @@ const meta: Meta<typeof FeedPage> = {
   component: FeedPage,
   decorators: [
     (Story) => (
-      <MainLayout>
-        <Story />
-      </MainLayout>
+      <div className="relative">
+        <MainLayout>
+          <Story />
+        </MainLayout>
+      </div>
     ),
   ],
 }

--- a/web/src/pages/SubmitLinkPage/SubmitLinkPage.stories.tsx
+++ b/web/src/pages/SubmitLinkPage/SubmitLinkPage.stories.tsx
@@ -8,9 +8,11 @@ const meta: Meta<typeof SubmitLinkPage> = {
   component: SubmitLinkPage,
   decorators: [
     (Story) => (
-      <MainLayout>
-        <Story />
-      </MainLayout>
+      <div className="relative">
+        <MainLayout>
+          <Story />
+        </MainLayout>
+      </div>
     ),
   ],
 }

--- a/web/src/pages/SubmitLinkPage/SubmitLinkPage.tsx
+++ b/web/src/pages/SubmitLinkPage/SubmitLinkPage.tsx
@@ -43,6 +43,7 @@ const SubmitLinkPage = () => {
         <div className="basis-7/12">
           <DisplayText
             solidText="submit"
+            solidTextColor="black"
             outlineText="a link"
             outlineColor="black"
           />


### PR DESCRIPTION
Need to fix a few things before I get farther:
- [x] adjust header styles - the current setup is messy and not what I want, actually fix this so it looks closer to the design and stops impacting the items below it
- [x] adjust the storybook background settings so that elements will show on the same background color they'll be on the real site, and make sure all stories are adjusted accordingly 
- [ ] enable the rls settings for tables in supabase and make any needed changes in the code to ensure the site keeps working as expected (but is now properly secure)