### PR TITLE
Fix display name logic

### DIFF
--- a/web/src/components/SharedLinksCell/SharedLinksCell.tsx
+++ b/web/src/components/SharedLinksCell/SharedLinksCell.tsx
@@ -49,7 +49,7 @@ export const Success = ({
     <ul>
       {sharedLinks.map((link) => {
         const displayName =
-          link.submittedBy.displayName ??
+          link.submittedBy.displayName ||
           link.submittedBy.email.slice(0, link.submittedBy.email.indexOf('@'))
         return (
           <SharedLink

--- a/web/src/pages/SignupPage/SignupPage.tsx
+++ b/web/src/pages/SignupPage/SignupPage.tsx
@@ -32,10 +32,12 @@ const SignupPage = () => {
   }, [])
 
   const onSubmit = async (data: Record<string, string>) => {
+    // this has to be set to null if they don't pick a display name, otherwise the unique constraint won't pass
+    const displayName = data.displayName !== '' ? data.displayName : null
     const response = await signUp({
       username: data.email,
       password: data.password,
-      displayName: data.displayName,
+      displayName,
     })
 
     if (response.message) {


### PR DESCRIPTION
Due to the changes made on the edit profile page, the shared link logic to check for a display name needed to be adjusted to handle empty strings. Also included a change to sign up so if no display name is picked, it sets it to null so the unique name constraint doesn't get triggered for an empty string.